### PR TITLE
Config file fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,7 +1363,7 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustfuzz"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "clap",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustfuzz"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2021"
 authors = ["Fuad Alizada fuadelizade6@gmail.com"]
 license = "LICENSE"

--- a/payloads/xss.txt
+++ b/payloads/xss.txt
@@ -1,0 +1,20 @@
+<script>alert(1)</script>
+"><img src=x onerror=alert(1)>
+'><svg/onload=alert(1)>
+"><svg/onload=confirm(1)>
+"><script>confirm(1)</script>
+"><iframe src="javascript:alert(1)">
+"><body onload=alert(1)>
+"><img src="x" onerror="prompt(1)">
+"><svg><script>alert(1)</script>
+"><input onfocus=alert(1) autofocus>
+"><details open ontoggle=alert(1)>
+"><marquee onstart=alert(1)>
+"><object data="javascript:alert(1)">
+"><embed src="javascript:alert(1)">
+"><a href="javascript:alert(1)">click</a>
+"><meta http-equiv="refresh" content="0;url=javascript:alert(1)">
+"><form onsubmit=alert(1)>
+"><button formaction="javascript:alert(1)">click</button>
+"><video src=_ onerror=alert(1)>
+"><audio src onerror=alert(1)>

--- a/rustfuzz.example.toml
+++ b/rustfuzz.example.toml
@@ -4,7 +4,7 @@
 url = "https://kyklos.site"
 
 # Path to your wordlist file
-#wordlist = "wordlists/w2.txt"
+wordlist = "wordlists/w2.txt"
 
 # Number of concurrent threads (default: 40)
 threads = 40
@@ -23,7 +23,7 @@ headers = [
 
 # Custom cookies (list of key-value pairs)
 cookies = [
-  ["session", ".eJwljjkOwkAMAP-yNZG89h42n0G-VtAmpEL8nUh0U4xG8ymPtefxLPf3fuatPF5R7oXJyNCoSWXuY0ogegxzZbmokocSOBNVn6zTBisGSFtdF-harNbZUSb2Nqv3Vashkufogo5ucFUzLAYnhl6KtzWpJUQKaLlGziP3_00CUIjwxmG6NU_feAVsFh1kNAMSLN8f2iI5BQ.aFqOcQ.Totuux6PlcVg5AOBsTHKjHsXETU"],
+  ["session", "Session_Key"],
   ["auth", "token"]
 ]
 
@@ -31,7 +31,7 @@ cookies = [
 #auth_token = "eyJhbGciOi..."
 
 # Proxy server (optional, e.g., "http://127.0.0.1:8080")
-#proxy = "http://127.0.0.1:8080"
+#proxy = "https://127.0.0.1:8080"
 
 # Rate limit between requests in milliseconds (optional)
 #rate_limit = 100
@@ -48,10 +48,10 @@ cookies = [
 
 # Enable crawling for endpoint discovery (set to true or false)
 # (Can also be enabled via --crawl)
-#crawl = true
+crawl = true
 
 # Optionally, specify an OpenAPI/Swagger spec URL for endpoint discovery
 # openapi = "https://example.com/openapi.json"
 
 # Optionally, analyze an export file
-analyze = "results/test1.csv"
+#analyze = "results/test1.csv"

--- a/rustfuzz.example.toml
+++ b/rustfuzz.example.toml
@@ -1,0 +1,57 @@
+# RustFuzz Example Configuration File
+
+# The base URL to fuzz or crawl (required unless using --analyze mode)
+url = "https://kyklos.site"
+
+# Path to your wordlist file
+#wordlist = "wordlists/w2.txt"
+
+# Number of concurrent threads (default: 40)
+threads = 40
+
+# Request timeout in seconds (default: 10)
+timeout = 15
+
+# Comma-separated list of status codes to match (default: "200,301,302,401,403,405,500")
+matcher = "200,301,302,405,500"
+
+# Custom headers (list of key-value pairs)
+headers = [
+  ["User-Agent", "RustFuzz/3.1"],
+  ["X-Api-Key", "your-api-key-here"]
+]
+
+# Custom cookies (list of key-value pairs)
+cookies = [
+  ["session", ".eJwljjkOwkAMAP-yNZG89h42n0G-VtAmpEL8nUh0U4xG8ymPtefxLPf3fuatPF5R7oXJyNCoSWXuY0ogegxzZbmokocSOBNVn6zTBisGSFtdF-harNbZUSb2Nqv3Vashkufogo5ucFUzLAYnhl6KtzWpJUQKaLlGziP3_00CUIjwxmG6NU_feAVsFh1kNAMSLN8f2iI5BQ.aFqOcQ.Totuux6PlcVg5AOBsTHKjHsXETU"],
+  ["auth", "token"]
+]
+
+# Bearer or other auth token (optional)
+#auth_token = "eyJhbGciOi..."
+
+# Proxy server (optional, e.g., "http://127.0.0.1:8080")
+#proxy = "http://127.0.0.1:8080"
+
+# Rate limit between requests in milliseconds (optional)
+#rate_limit = 100
+
+# Export results to a file (json or csv)
+#export = "results/output.json"
+
+# Enable mutation-based fuzzing (set to true or false)
+# (Can also be enabled via --mutate)
+#mutate = true
+
+# Additional payloads file (optional)
+#payloads = "payloads/xss.txt"
+
+# Enable crawling for endpoint discovery (set to true or false)
+# (Can also be enabled via --crawl)
+#crawl = true
+
+# Optionally, specify an OpenAPI/Swagger spec URL for endpoint discovery
+# openapi = "https://example.com/openapi.json"
+
+# Optionally, analyze an export file
+analyze = "results/test1.csv"


### PR DESCRIPTION
This pull request introduces several enhancements to the `rustfuzz` project, including support for configuration files, expanded functionality, and improved usability. Key changes include the addition of a TOML-based configuration file, new command-line options, and updates to the payload handling and fuzzing logic.

### Configuration and CLI Enhancements:
* Added support for a TOML-based configuration file (`rustfuzz.example.toml`) to simplify and centralize settings management. New options include `crawl`, `mutate`, `payloads`, and `openapi`.
* Updated the `Config` struct in `src/main.rs` to include new fields such as `crawl`, `mutate`, and `payloads`, allowing for more flexible configuration.
* Enhanced the CLI to support the `--config` option, enabling users to load settings from a configuration file. Command-line arguments now override configuration file values.

### Payload and Fuzzing Improvements:
* Added a comprehensive set of XSS payloads in `payloads/xss.txt` to expand the fuzzing capabilities.
* Improved mutation-based fuzzing and payload handling by integrating configuration file options and enabling unified feature switches for `crawl`, `mutate`, and `payloads`.

### Version and Metadata Updates:
* Updated the version of `rustfuzz` from `3.1.0` to `3.2.0` in `Cargo.toml` and `src/main.rs`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL55-R66)

### OpenAPI and Analysis Enhancements:
* Added support for OpenAPI endpoint discovery via the `openapi` configuration option, providing a foundation for future improvements in endpoint parsing.
* Enhanced result analysis by allowing users to analyze export files directly from the configuration or command-line arguments.

These changes significantly improve the flexibility, usability, and functionality of `rustfuzz`, making it a more robust tool for web fuzzing and endpoint discovery.

Closes #9 