### PR TITLE
Fixed proxy problems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,7 +1134,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "web-time",
@@ -1149,7 +1155,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1323,6 +1329,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-socks",
  "tokio-util",
  "tower",
  "tower-service",
@@ -1363,7 +1370,7 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustfuzz"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "clap",
  "csv",
@@ -1665,11 +1672,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1785,6 +1812,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustfuzz"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2021"
 authors = ["Fuad Alizada fuadelizade6@gmail.com"]
 license = "LICENSE"
@@ -15,7 +15,7 @@ futures = "0.3"
 indicatif = "0.17"
 rand = "0.8"
 regex = "1"
-reqwest = { version = "0.12", features = ["json", "gzip", "cookies", "stream", "rustls-tls"] }
+reqwest = { version = "0.12", features = ["json", "gzip", "cookies", "stream", "rustls-tls", "socks"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.37", features = ["full"] }

--- a/rustfuzz.example.toml
+++ b/rustfuzz.example.toml
@@ -1,10 +1,10 @@
 # RustFuzz Example Configuration File
 
 # The base URL to fuzz or crawl (required unless using --analyze mode)
-url = "https://kyklos.site"
+url = "https://example.com"
 
 # Path to your wordlist file
-wordlist = "wordlists/w2.txt"
+#wordlist = "wordlists/w2.txt"
 
 # Number of concurrent threads (default: 40)
 threads = 40
@@ -31,7 +31,10 @@ cookies = [
 #auth_token = "eyJhbGciOi..."
 
 # Proxy server (optional, e.g., "http://127.0.0.1:8080")
-#proxy = "https://127.0.0.1:8080"
+#proxy = "http://127.0.0.1:8080"
+#proxy = "socks5://103.90.228.7:46530"
+#proxy = "http://103.237.144.232:1311"
+
 
 # Rate limit between requests in milliseconds (optional)
 #rate_limit = 100
@@ -48,7 +51,7 @@ cookies = [
 
 # Enable crawling for endpoint discovery (set to true or false)
 # (Can also be enabled via --crawl)
-crawl = true
+#crawl = true
 
 # Optionally, specify an OpenAPI/Swagger spec URL for endpoint discovery
 # openapi = "https://example.com/openapi.json"

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,12 +57,12 @@ async fn main() {
         | | \ \ |_| \__ \ |_| | | |_| |/ / / / 
         |_|  \_\__,_|___/\__|_|  \__,_/___/___|
                                        
-        rustfuzz - v3.2.0
+        rustfuzz - v3.3.0
         "#
     );
 
     let matches = Command::new("rustfuzz")
-        .version("3.2.0")
+        .version("3.3.0")
         .author("Martian58")
         .about("Website fuzzer written in Rust - advanced edition")
         .arg(
@@ -251,6 +251,9 @@ async fn main() {
     if let Some(payloads) = matches.get_one::<String>("payloads") {
         config.payloads = Some(payloads.clone());
     }
+    if let Some(proxy) = matches.get_one::<String>("proxy") {
+        config.proxy = Some(proxy.clone());
+    }
     if let Some(analyze) = matches.get_one::<String>("analyze") {
         config.analyze = Some(analyze.clone());
     }
@@ -285,6 +288,9 @@ async fn main() {
     println!(":: Matcher          : {:?}", status_codes);
     if let Some(proxy) = &config.proxy {
         println!(":: Proxy            : {}", proxy);
+    }
+    if let Some(payloads) = &config.payloads {
+        println!(":: Payloads         : {}", payloads);
     }
     if let Some(export) = &config.export {
         println!(":: Export           : {}", export);
@@ -354,6 +360,7 @@ async fn main() {
     );
 
     let mut client_builder = Client::builder().timeout(Duration::from_secs(timeout));
+    client_builder = client_builder.danger_accept_invalid_certs(true); // Add this line for Burp
     if let Some(proxy) = &config.proxy {
         client_builder = client_builder.proxy(Proxy::all(proxy).expect("Invalid proxy"));
     }
@@ -417,7 +424,7 @@ async fn main() {
                     }
                     Err(_e) => {
                         // Always show and export network errors
-                        // println!("ERR  - {target} [error: {e}]");
+                        // println!("ERR  - {target} [error: {_e}]");
                         // let r = FuzzResult {
                         //     url: target.clone(),
                         //     word: word.to_string(),


### PR DESCRIPTION
This pull request updates the `rustfuzz` package to version 3.3.0, introduces new features like SOCKS proxy support and payload configuration, and refines the example configuration file and main application logic. The changes enhance flexibility and usability, particularly for advanced users needing proxy configurations and payload management.

### Version update and dependency enhancements:
* Updated `Cargo.toml` to reflect the new version `3.3.0` of `rustfuzz`.
* Added SOCKS proxy support to the `reqwest` dependency by including the `socks` feature.

### Configuration file refinements:
* Updated the example configuration file (`rustfuzz.example.toml`) with a new base URL (`https://example.com`) and commented out the wordlist path for clarity.
* Added multiple proxy examples, including SOCKS5 and HTTP proxies, for better user guidance.
* Commented out the `crawl` option in the example configuration file for optional use.

### Application logic improvements:
* Updated `src/main.rs` to reflect the new version `3.3.0` in the application banner and command metadata.
* Added support for configuring proxies and payloads via command-line arguments and updated the configuration object accordingly. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR254-R256) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR292-R294)
* Enhanced the HTTP client builder to accept invalid certificates, improving compatibility with tools like Burp Suite.

### Minor fixes:
* Adjusted error handling in `src/main.rs` to use a placeholder variable (`_e`) for better readability.

Closes #10 